### PR TITLE
Refactor FastAPI app to use modular backend services

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,305 +1,27 @@
-# app.py
-# pip install fastapi uvicorn "openai>=1.40.0" pandas openpyxl PyPDF2 python-docx
-import os
+"""FastAPI application entry point."""
+
+from __future__ import annotations
+
 import sys
-import math
-import time
-import csv
-import pickle
-import hashlib
-from dataclasses import dataclass
-from typing import List, Tuple, Dict, Any, Optional, Literal
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from pydantic import BaseModel, Field
-from openai import AzureOpenAI
 
-from project_dashboard import load_project_tasks, router as project_dashboard_router
+from project_dashboard import router as project_dashboard_router
 
-# ===================== Config =====================
 try:
-    import config
-except Exception:
-    config = None
-
-ENDPOINT_URL = os.getenv("ENDPOINT_URL") or getattr(config, "ENDPOINT_URL", None)
-DEPLOYMENT_NAME = os.getenv("DEPLOYMENT_NAME") or getattr(config, "DEPLOYMENT_NAME", None)
-AZURE_OPENAI_API_KEY = os.getenv("AZURE_OPENAI_API_KEY") or getattr(config, "AZURE_OPENAI_API_KEY", None)
-EMBEDDING_DEPLOYMENT_NAME = os.getenv("EMBEDDING_DEPLOYMENT_NAME") or getattr(config, "EMBEDDING_DEPLOYMENT_NAME", None)
-
-if not ENDPOINT_URL or not DEPLOYMENT_NAME or not AZURE_OPENAI_API_KEY or not EMBEDDING_DEPLOYMENT_NAME:
-    print("Please set ENDPOINT_URL, DEPLOYMENT_NAME, AZURE_OPENAI_API_KEY, EMBEDDING_DEPLOYMENT_NAME (env or config.py).")
+    from rag_backend.api_models import (
+        AskBody,
+        AskErrorResponse,
+        AskSuccessResponse,
+        BuildBody,
+        BuildResponse,
+    )
+    from rag_backend.service import handle_ask_request, handle_build_request
+except RuntimeError as exc:  # pragma: no cover - configuration validation
+    print(exc)
     sys.exit(1)
 
-client = AzureOpenAI(
-    azure_endpoint=ENDPOINT_URL,
-    api_key=AZURE_OPENAI_API_KEY,
-    api_version="2025-01-01-preview",
-)
-
-SOURCE_DIR = "./data_sources"
-DEFAULT_TOP_K = 3
-LOG_DIR = "./logs"
-os.makedirs(SOURCE_DIR, exist_ok=True)
-os.makedirs(LOG_DIR, exist_ok=True)
-LOG_PATH = os.path.join(LOG_DIR, "query_logs.csv")
-
-# ===================== I/O helpers =====================
-def read_text_file(path: str) -> str:
-    with open(path, "r", encoding="utf-8", errors="ignore") as f:
-        return f.read()
-
-def read_pdf(path: str) -> str:
-    try:
-        import PyPDF2
-    except ImportError:
-        raise RuntimeError("PyPDF2 not installed. Run: pip install PyPDF2")
-    text = []
-    with open(path, "rb") as f:
-        reader = PyPDF2.PdfReader(f)
-        for i in range(len(reader.pages)):
-            try:
-                text.append(reader.pages[i].extract_text() or "")
-            except Exception:
-                text.append("")
-    return "\n".join(text)
-
-def load_document(path: str) -> str:
-    p = path.lower()
-    if p.endswith((".txt", ".md")):
-        return read_text_file(path)
-    elif p.endswith(".pdf"):
-        return read_pdf(path)
-    elif p.endswith((".xlsx", ".xls")):
-        try:
-            import pandas as pd
-        except ImportError:
-            raise RuntimeError("pandas required for Excel. Run: pip install pandas openpyxl xlrd")
-        df_map = pd.read_excel(path, sheet_name=None)
-        texts = []
-        for sheet, sdf in df_map.items():
-            head = f"--- Sheet: {sheet} ---"
-            sdf = sdf.fillna("")
-            rows = sdf.to_dict(orient="records")
-            row_lines = [" | ".join(f"{k}={v}" for k, v in r.items()) for r in rows]
-            texts.append(head + "\n" + "\n".join(row_lines))
-        return "\n\n".join(texts)
-    elif p.endswith(".csv"):
-        try:
-            import pandas as pd
-        except ImportError:
-            raise RuntimeError("pandas required for CSV. Run: pip install pandas")
-        df = pd.read_csv(path).fillna("")
-        rows = df.to_dict(orient="records")
-        return "\n".join(" | ".join(f"{k}={v}" for k, v in r.items()) for r in rows)
-    elif p.endswith(".docx"):
-        try:
-            import docx
-        except ImportError:
-            raise RuntimeError("python-docx required for Word files. Run: pip install python-docx")
-        doc = docx.Document(path)
-        paras = [p.text.strip() for p in doc.paragraphs if p.text and p.text.strip()]
-        return "\n".join(paras)
-    else:
-        try:
-            return read_text_file(path)
-        except Exception:
-            raise RuntimeError(f"Unsupported file type: {path}")
-
-# ===================== Chunking & embeddings =====================
-def chunk_text(text: str, max_chars: int = 1500, overlap: int = 150) -> List[str]:
-    paras = [p.strip() for p in text.split("\n") if p.strip()]
-    chunks: List[str] = []
-    buf = ""
-    for p in paras:
-        if len(buf) + len(p) + 1 <= max_chars:
-            buf = (buf + "\n" + p).strip()
-        else:
-            if buf:
-                chunks.append(buf)
-            if len(p) > max_chars:
-                start = 0
-                while start < len(p):
-                    end = start + max_chars
-                    chunks.append(p[start:end])
-                    start = max(0, end - overlap)
-            else:
-                buf = p
-    if buf:
-        chunks.append(buf)
-
-    if overlap <= 0:
-        return chunks
-
-    overlapped: List[str] = []
-    for i, c in enumerate(chunks):
-        if i == 0:
-            overlapped.append(c)
-        else:
-            prev = chunks[i - 1]
-            tail = prev[-overlap:]
-            overlapped.append((tail + "\n" + c).strip())
-    return overlapped
-
-def embed_texts(texts: List[str]) -> List[List[float]]:
-    out: List[List[float]] = []
-    BATCH = 16
-    for i in range(0, len(texts), BATCH):
-        batch = texts[i : i + BATCH]
-        resp = client.embeddings.create(model=EMBEDDING_DEPLOYMENT_NAME, input=batch)
-        out.extend([d.embedding for d in resp.data])
-    return out
-
-def cosine_similarity(a: List[float], b: List[float]) -> float:
-    dot = sum(x * y for x, y in zip(a, b))
-    na = math.sqrt(sum(x * x for x in a))
-    nb = math.sqrt(sum(y * y for y in b))
-    if na == 0 or nb == 0:
-        return 0.0
-    return dot / (na * nb)
-
-# ===================== On-disk index (PKL next to each XLSX) =====================
-@dataclass
-class IndexFile:
-    pkl_path: str
-    chunks: List[str]
-    embeddings: List[List[float]]
-    signature: str
-
-def file_signature(path: str) -> str:
-    h = hashlib.sha256()
-    with open(path, "rb") as f:
-        for b in iter(lambda: f.read(1024 * 1024), b""):
-            h.update(b)
-    st = os.stat(path)
-    h.update(str(st.st_size).encode())
-    h.update(str(int(st.st_mtime)).encode())
-    return h.hexdigest()
-
-def pkl_path_for(doc_path: str) -> str:
-    base = os.path.basename(doc_path)
-    return os.path.join(os.path.dirname(doc_path), f"{base}.{EMBEDDING_DEPLOYMENT_NAME}.idx.pkl")
-
-def load_index_if_valid(doc_path: str) -> Optional[IndexFile]:
-    pklp = pkl_path_for(doc_path)
-    if not os.path.exists(pklp):
-        return None
-    try:
-        with open(pklp, "rb") as f:
-            obj = pickle.load(f)
-        if not isinstance(obj, dict):
-            return None
-        if obj.get("embedding_model") != EMBEDDING_DEPLOYMENT_NAME:
-            return None
-        if obj.get("doc_signature") != file_signature(doc_path):
-            return None
-        return IndexFile(
-            pkl_path=pklp,
-            chunks=obj["chunks"],
-            embeddings=obj["embeddings"],
-            signature=obj["doc_signature"],
-        )
-    except Exception:
-        return None
-
-def build_index(doc_path: str) -> IndexFile:
-    raw = load_document(doc_path)
-    chunks = chunk_text(raw, 1500, 150)
-    if not chunks:
-        raise RuntimeError(f"No text extracted from {doc_path}")
-    embs = embed_texts(chunks)
-    sig = file_signature(doc_path)
-    payload = {
-        "doc_signature": sig,
-        "embedding_model": EMBEDDING_DEPLOYMENT_NAME,
-        "chunks": chunks,
-        "embeddings": embs,
-    }
-    pklp = pkl_path_for(doc_path)
-    with open(pklp, "wb") as f:
-        pickle.dump(payload, f)
-    return IndexFile(pkl_path=pklp, chunks=chunks, embeddings=embs, signature=sig)
-
-def ensure_index(doc_path: str, rebuild: bool = False) -> IndexFile:
-    if not rebuild:
-        idx = load_index_if_valid(doc_path)
-        if idx:
-            return idx
-    return build_index(doc_path)
-
-def list_xlsx(source_dir: str) -> List[str]:
-    if not os.path.isdir(source_dir):
-        raise FileNotFoundError(f"Source dir not found: {source_dir}")
-    out = []
-    for name in os.listdir(source_dir):
-        if name.lower().endswith((".xlsx", ".xls")):
-            out.append(os.path.join(source_dir, name))
-    return sorted(out)
-
-# ===================== Retrieval & LLM =====================
-def retrieve_top_k(question: str, all_chunks: List[str], all_embs: List[List[float]], k: int) -> List[Tuple[int, float]]:
-    q_emb = client.embeddings.create(model=EMBEDDING_DEPLOYMENT_NAME, input=[question]).data[0].embedding
-    sims = [(i, cosine_similarity(q_emb, emb)) for i, emb in enumerate(all_embs)]
-    sims.sort(key=lambda x: x[1], reverse=True)
-    return sims[:k]
-
-def build_messages(retrieved_chunks: List[str], question: str) -> List[Dict[str, str]]:
-    context_block = "\n\n".join([f"[Chunk {i+1}]\n{c}" for i, c in enumerate(retrieved_chunks)])
-    system_text = (
-        "You are a helpful AI assistant. Use ONLY the provided context to answer the question. "
-        "If the answer is not in the context, say you don't know and suggest what would help."
-    )
-    user_text = (
-        "Here is the context from the document(s):\n"
-        f"{context_block}\n\n"
-        f"Question: {question}\n\n"
-        "Answer clearly. If relevant, quote short snippets."
-    )
-    return [
-        {"role": "system", "content": system_text},
-        {"role": "user", "content": user_text},
-    ]
-
-def ask_llm(messages: List[Dict[str, str]], temperature: float = 1, max_completion_tokens: int = 10000) -> Tuple[str, Dict[str, Optional[int]], float]:
-    t0 = time.time()
-    completion = client.chat.completions.create(
-        model=DEPLOYMENT_NAME,
-        messages=messages,
-        max_completion_tokens=max_completion_tokens,     # correct param for Chat Completions API
-        temperature=temperature,
-    )
-    dt = time.time() - t0
-    msg = completion.choices[0].message
-    usage = getattr(completion, "usage", None)
-    tokens = {
-        "prompt_tokens": getattr(usage, "prompt_tokens", None),
-        "completion_tokens": getattr(usage, "completion_tokens", None),
-        "total_tokens": getattr(usage, "total_tokens", None),
-    } if usage else {}
-    return (msg.content or "").strip(), tokens, dt
-
-# ===================== Logging =====================
-def log_query(row: Dict[str, Any]) -> None:
-    file_exists = os.path.exists(LOG_PATH)
-    with open(LOG_PATH, "a", newline="", encoding="utf-8") as f:
-        writer = csv.DictWriter(
-            f,
-            fieldnames=[
-                "timestamp",
-                "question",
-                "top_k",
-                "prompt_tokens",
-                "completion_tokens",
-                "total_tokens",
-                "duration_sec",
-            ],
-        )
-        if not file_exists:
-            writer.writeheader()
-        writer.writerow(row)
-
-# ===================== FastAPI app =====================
 app = FastAPI(
     title="RAG Project Management Backend",
     description=(
@@ -333,111 +55,6 @@ app.add_middleware(
 
 app.include_router(project_dashboard_router)
 
-class BuildBody(BaseModel):
-    """Request payload for `/build` to trigger index creation."""
-
-    rebuild: bool = Field(
-        False,
-        description=(
-            "Recreate indexes even if cached embeddings already exist for the source "
-            "workbooks."
-        ),
-    )
-
-
-class IndexedFileSummary(BaseModel):
-    """Summary of an indexed workbook and its embedding cache."""
-
-    xlsx: str = Field(..., description="Workbook filename that was processed.")
-    pkl: str = Field(..., description="Generated embedding cache filename.")
-    chunks: int = Field(..., description="Number of text chunks extracted from the workbook.")
-    signature: str = Field(
-        ..., description="Short hash of the workbook contents used for cache validation."
-    )
-
-
-class ProjectDashboardStatus(BaseModel):
-    """Status information about the project dashboard cache."""
-
-    ok: bool = Field(..., description="Whether project dashboard data is available.")
-    count: Optional[int] = Field(
-        None, description="Number of cached project tasks when available."
-    )
-    error: Optional[str] = Field(
-        None, description="Details when the dashboard data could not be loaded."
-    )
-
-
-class BuildResponse(BaseModel):
-    """Response returned by the `/build` endpoint."""
-
-    ok: Literal[True] = Field(True, description="Whether the build completed successfully.")
-    built: List[IndexedFileSummary] = Field(
-        default_factory=list,
-        description="Details for each workbook that was indexed.",
-    )
-    message: Optional[str] = Field(
-        None, description="Helpful message when no workbooks were available to index."
-    )
-    project_dashboard: ProjectDashboardStatus = Field(
-        ..., description="Status of the project dashboard cache after the build runs."
-    )
-
-
-class AskBody(BaseModel):
-    """Request payload for `/ask` to run a RAG-powered query."""
-
-    question: str = Field(..., description="Natural language question to ask over the data.")
-    top_k: Optional[int] = Field(
-        None,
-        description="Number of most similar chunks to retrieve from the index (defaults to 3).",
-        ge=1,
-    )
-    temperature: Optional[float] = Field(
-        None,
-        description=(
-            "Sampling temperature for the language model. Leave unset to use the "
-            "default configuration."
-        ),
-        ge=0.0,
-    )
-
-
-class TokenUsage(BaseModel):
-    """Token accounting metadata returned by Azure OpenAI."""
-
-    prompt_tokens: Optional[int] = Field(
-        None, description="Tokens consumed by the prompt portion of the request."
-    )
-    completion_tokens: Optional[int] = Field(
-        None, description="Tokens generated in the completion response."
-    )
-    total_tokens: Optional[int] = Field(
-        None, description="Total tokens counted for the request.")
-
-
-class AskSuccessResponse(BaseModel):
-    """Successful response for the `/ask` endpoint."""
-
-    ok: Literal[True] = Field(True, description="Indicates the question was processed.")
-    answer: str = Field(..., description="Generated answer from the language model.")
-    usage: Optional[TokenUsage] = Field(
-        None, description="Token usage metrics reported by the language model."
-    )
-    duration_sec: float = Field(..., description="Time taken to build the response in seconds.")
-    top_scores: List[float] = Field(
-        ..., description="Similarity scores for the retrieved context chunks."
-    )
-    indexed_files: List[str] = Field(
-        ..., description="Workbook filenames that contributed to the retrieval context."
-    )
-
-
-class AskErrorResponse(BaseModel):
-    """Error payload returned when the `/ask` endpoint cannot run."""
-
-    ok: Literal[False] = Field(False, description="Indicates the question could not be run.")
-    error: str = Field(..., description="Reason why the request failed.")
 
 @app.post(
     "/build",
@@ -447,39 +64,8 @@ class AskErrorResponse(BaseModel):
     response_description="Details about the index build and project dashboard cache.",
 )
 def build_indexes(body: BuildBody) -> BuildResponse:
-    xlsx_list = list_xlsx(SOURCE_DIR)
-    if not xlsx_list:
-        response: Dict[str, Any] = {
-            "ok": True,
-            "built": [],
-            "message": "No .xlsx/.xls files found in ./data_sources.",
-        }
-        try:
-            dashboard = load_project_tasks()
-        except FileNotFoundError:
-            dashboard = {"ok": False, "error": "Project tasks workbook not found."}
-        except Exception as exc:  # pragma: no cover - defensive
-            dashboard = {"ok": False, "error": str(exc)}
-        response["project_dashboard"] = ProjectDashboardStatus(**dashboard)
-        return BuildResponse(**response)
+    return handle_build_request(body)
 
-    built = []
-    for path in xlsx_list:
-        idx = ensure_index(path, rebuild=body.rebuild)
-        built.append({
-            "xlsx": os.path.basename(path),
-            "pkl": os.path.basename(idx.pkl_path),
-            "chunks": len(idx.chunks),
-            "signature": idx.signature[:16]
-        })
-    try:
-        dashboard = load_project_tasks()
-    except FileNotFoundError:
-        dashboard = {"ok": False, "error": "Project tasks workbook not found."}
-    except Exception as exc:  # pragma: no cover - defensive
-        dashboard = {"ok": False, "error": str(exc)}
-
-    return BuildResponse(built=built, project_dashboard=ProjectDashboardStatus(**dashboard))
 
 @app.post(
     "/ask",
@@ -489,50 +75,10 @@ def build_indexes(body: BuildBody) -> BuildResponse:
     response_description="Generated answer or an error describing why the request failed.",
 )
 def ask_question(body: AskBody) -> AskSuccessResponse | AskErrorResponse:
-    top_k = body.top_k or DEFAULT_TOP_K
-    temperature = 1 if body.temperature is None else body.temperature
+    return handle_ask_request(body)
 
-    xlsx_list = list_xlsx(SOURCE_DIR)
-    if not xlsx_list:
-        return AskErrorResponse(
-            error="No .xlsx/.xls files in ./data_sources. Build first via /build."
-        )
 
-    all_chunks: List[str] = []
-    all_embs: List[List[float]] = []
-    for path in xlsx_list:
-        idx = ensure_index(path, rebuild=False)
-        all_chunks.extend(idx.chunks)
-        all_embs.extend(idx.embeddings)
-
-    top = retrieve_top_k(body.question, all_chunks, all_embs, k=top_k)
-    retrieved = [all_chunks[i] for i, _ in top]
-    top_scores = [round(s, 4) for _, s in top]
-
-    messages = build_messages(retrieved, body.question)
-    answer, usage, duration = ask_llm(messages, temperature=temperature, max_completion_tokens=10000)
-
-    now_iso = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime())
-    log_query({
-        "timestamp": now_iso,
-        "question": body.question,
-        "top_k": top_k,
-        "prompt_tokens": usage.get("prompt_tokens"),
-        "completion_tokens": usage.get("completion_tokens"),
-        "total_tokens": usage.get("total_tokens"),
-        "duration_sec": round(duration, 3),
-    })
-
-    token_usage = TokenUsage(**usage) if usage else None
-
-    return AskSuccessResponse(
-        answer=answer,
-        usage=token_usage,
-        duration_sec=round(duration, 3),
-        top_scores=top_scores,
-        indexed_files=[os.path.basename(p) for p in xlsx_list],
-    )
-
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover - manual execution helper
     import uvicorn
+
     uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/rag_backend/__init__.py
+++ b/rag_backend/__init__.py
@@ -1,0 +1,1 @@
+"""Core utilities for the RAG project management backend."""

--- a/rag_backend/api_models.py
+++ b/rag_backend/api_models.py
@@ -1,0 +1,123 @@
+"""Pydantic models shared across API routes."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Literal, Optional
+
+from pydantic import BaseModel, Field
+
+
+class BuildBody(BaseModel):
+    """Request payload for `/build` to trigger index creation."""
+
+    rebuild: bool = Field(
+        False,
+        description=(
+            "Recreate indexes even if cached embeddings already exist for the source "
+            "workbooks."
+        ),
+    )
+
+
+class IndexedFileSummary(BaseModel):
+    """Summary of an indexed workbook and its embedding cache."""
+
+    xlsx: str = Field(..., description="Workbook filename that was processed.")
+    pkl: str = Field(..., description="Generated embedding cache filename.")
+    chunks: int = Field(..., description="Number of text chunks extracted from the workbook.")
+    signature: str = Field(
+        ..., description="Short hash of the workbook contents used for cache validation."
+    )
+
+
+class ProjectDashboardStatus(BaseModel):
+    """Status information about the project dashboard cache."""
+
+    ok: bool = Field(..., description="Whether project dashboard data is available.")
+    count: Optional[int] = Field(
+        None, description="Number of cached project tasks when available."
+    )
+    error: Optional[str] = Field(
+        None, description="Details when the dashboard data could not be loaded."
+    )
+
+
+class BuildResponse(BaseModel):
+    """Response returned by the `/build` endpoint."""
+
+    ok: Literal[True] = Field(True, description="Whether the build completed successfully.")
+    built: List[IndexedFileSummary] = Field(
+        default_factory=list,
+        description="Details for each workbook that was indexed.",
+    )
+    message: Optional[str] = Field(
+        None, description="Helpful message when no workbooks were available to index."
+    )
+    project_dashboard: ProjectDashboardStatus = Field(
+        ..., description="Status of the project dashboard cache after the build runs."
+    )
+
+
+class AskBody(BaseModel):
+    """Request payload for `/ask` to run a RAG-powered query."""
+
+    question: str = Field(..., description="Natural language question to ask over the data.")
+    top_k: Optional[int] = Field(
+        None,
+        description="Number of most similar chunks to retrieve from the index (defaults to 3).",
+        ge=1,
+    )
+    temperature: Optional[float] = Field(
+        None,
+        description=(
+            "Sampling temperature for the language model. Leave unset to use the "
+            "default configuration."
+        ),
+        ge=0.0,
+    )
+
+
+class TokenUsage(BaseModel):
+    """Token accounting metadata returned by Azure OpenAI."""
+
+    prompt_tokens: Optional[int] = Field(
+        None, description="Tokens consumed by the prompt portion of the request."
+    )
+    completion_tokens: Optional[int] = Field(
+        None, description="Tokens generated in the completion response."
+    )
+    total_tokens: Optional[int] = Field(
+        None, description="Total tokens counted for the request."
+    )
+
+
+class AskSuccessResponse(BaseModel):
+    """Successful response for the `/ask` endpoint."""
+
+    ok: Literal[True] = Field(True, description="Indicates the question was processed.")
+    answer: str = Field(..., description="Generated answer from the language model.")
+    usage: Optional[TokenUsage] = Field(
+        None, description="Token usage metrics reported by the language model."
+    )
+    duration_sec: float = Field(..., description="Time taken to build the response in seconds.")
+    top_scores: List[float] = Field(
+        ..., description="Similarity scores for the retrieved context chunks."
+    )
+    indexed_files: List[str] = Field(
+        ..., description="Workbook filenames that contributed to the retrieval context."
+    )
+
+
+class AskErrorResponse(BaseModel):
+    """Error payload returned when the `/ask` endpoint cannot run."""
+
+    ok: Literal[False] = Field(False, description="Indicates the question could not be run.")
+    error: str = Field(..., description="Reason why the request failed.")
+
+
+def to_token_usage(payload: Dict[str, Any] | None) -> Optional[TokenUsage]:
+    """Convert a usage dictionary into a :class:`TokenUsage` instance."""
+
+    if not payload:
+        return None
+    return TokenUsage(**payload)

--- a/rag_backend/azure.py
+++ b/rag_backend/azure.py
@@ -1,0 +1,20 @@
+"""Azure OpenAI client factory."""
+
+from __future__ import annotations
+
+from openai import AzureOpenAI
+
+from .settings import AZURE_SETTINGS
+
+
+def create_client() -> AzureOpenAI:
+    """Create an Azure OpenAI client using the configured settings."""
+
+    return AzureOpenAI(
+        azure_endpoint=AZURE_SETTINGS.endpoint_url,
+        api_key=AZURE_SETTINGS.api_key,
+        api_version=AZURE_SETTINGS.api_version,
+    )
+
+
+AZURE_CLIENT = create_client()

--- a/rag_backend/chunking.py
+++ b/rag_backend/chunking.py
@@ -1,0 +1,40 @@
+"""Text chunking helpers."""
+
+from __future__ import annotations
+
+from typing import List
+
+
+def chunk_text(text: str, max_chars: int = 1500, overlap: int = 150) -> List[str]:
+    paragraphs = [paragraph.strip() for paragraph in text.split("\n") if paragraph.strip()]
+    chunks: List[str] = []
+    buffer = ""
+    for paragraph in paragraphs:
+        if len(buffer) + len(paragraph) + 1 <= max_chars:
+            buffer = (buffer + "\n" + paragraph).strip()
+        else:
+            if buffer:
+                chunks.append(buffer)
+            if len(paragraph) > max_chars:
+                start = 0
+                while start < len(paragraph):
+                    end = start + max_chars
+                    chunks.append(paragraph[start:end])
+                    start = max(0, end - overlap)
+            else:
+                buffer = paragraph
+    if buffer:
+        chunks.append(buffer)
+
+    if overlap <= 0:
+        return chunks
+
+    overlapped: List[str] = []
+    for index, chunk in enumerate(chunks):
+        if index == 0:
+            overlapped.append(chunk)
+        else:
+            previous = chunks[index - 1]
+            tail = previous[-overlap:]
+            overlapped.append((tail + "\n" + chunk).strip())
+    return overlapped

--- a/rag_backend/documents.py
+++ b/rag_backend/documents.py
@@ -1,0 +1,83 @@
+"""Helpers for loading and normalising document content."""
+
+from __future__ import annotations
+
+from typing import List
+
+
+def read_text_file(path: str) -> str:
+    with open(path, "r", encoding="utf-8", errors="ignore") as file:
+        return file.read()
+
+
+def read_pdf(path: str) -> str:
+    try:
+        import PyPDF2
+    except ImportError as exc:  # pragma: no cover - dependency guard
+        raise RuntimeError("PyPDF2 not installed. Run: pip install PyPDF2") from exc
+
+    text: List[str] = []
+    with open(path, "rb") as file:
+        reader = PyPDF2.PdfReader(file)
+        for page in reader.pages:
+            try:
+                text.append(page.extract_text() or "")
+            except Exception:  # pragma: no cover - defensive against malformed PDFs
+                text.append("")
+    return "\n".join(text)
+
+
+def load_document(path: str) -> str:
+    lower_path = path.lower()
+    if lower_path.endswith((".txt", ".md")):
+        return read_text_file(path)
+    if lower_path.endswith(".pdf"):
+        return read_pdf(path)
+    if lower_path.endswith((".xlsx", ".xls")):
+        try:
+            import pandas as pd
+        except ImportError as exc:  # pragma: no cover - dependency guard
+            raise RuntimeError(
+                "pandas required for Excel. Run: pip install pandas openpyxl xlrd"
+            ) from exc
+        dataframes = pd.read_excel(path, sheet_name=None)
+        sections = []
+        for sheet, dataframe in dataframes.items():
+            header = f"--- Sheet: {sheet} ---"
+            dataframe = dataframe.fillna("")
+            rows = dataframe.to_dict(orient="records")
+            row_lines = [
+                " | ".join(f"{key}={value}" for key, value in row.items())
+                for row in rows
+            ]
+            sections.append(header + "\n" + "\n".join(row_lines))
+        return "\n\n".join(sections)
+    if lower_path.endswith(".csv"):
+        try:
+            import pandas as pd
+        except ImportError as exc:  # pragma: no cover - dependency guard
+            raise RuntimeError("pandas required for CSV. Run: pip install pandas") from exc
+        dataframe = pd.read_csv(path).fillna("")
+        rows = dataframe.to_dict(orient="records")
+        return "\n".join(
+            " | ".join(f"{key}={value}" for key, value in row.items()) for row in rows
+        )
+    if lower_path.endswith(".docx"):
+        try:
+            import docx
+        except ImportError as exc:  # pragma: no cover - dependency guard
+            raise RuntimeError(
+                "python-docx required for Word files. Run: pip install python-docx"
+            ) from exc
+        document = docx.Document(path)
+        paragraphs = [
+            paragraph.text.strip()
+            for paragraph in document.paragraphs
+            if paragraph.text and paragraph.text.strip()
+        ]
+        return "\n".join(paragraphs)
+
+    try:
+        return read_text_file(path)
+    except Exception as exc:  # pragma: no cover - defensive
+        raise RuntimeError(f"Unsupported file type: {path}") from exc

--- a/rag_backend/embeddings.py
+++ b/rag_backend/embeddings.py
@@ -1,0 +1,33 @@
+"""Embedding helpers that wrap Azure OpenAI operations."""
+
+from __future__ import annotations
+
+import math
+from typing import Iterable, List
+
+from openai import AzureOpenAI
+
+
+def embed_texts(client: AzureOpenAI, model: str, texts: Iterable[str]) -> List[List[float]]:
+    """Generate embeddings for a collection of texts."""
+
+    text_list = list(texts)
+    if not text_list:
+        return []
+
+    embeddings: List[List[float]] = []
+    batch_size = 16
+    for start in range(0, len(text_list), batch_size):
+        batch = text_list[start : start + batch_size]
+        response = client.embeddings.create(model=model, input=batch)
+        embeddings.extend([item.embedding for item in response.data])
+    return embeddings
+
+
+def cosine_similarity(a: List[float], b: List[float]) -> float:
+    dot = sum(x * y for x, y in zip(a, b))
+    norm_a = math.sqrt(sum(x * x for x in a))
+    norm_b = math.sqrt(sum(y * y for y in b))
+    if norm_a == 0 or norm_b == 0:
+        return 0.0
+    return dot / (norm_a * norm_b)

--- a/rag_backend/indexing.py
+++ b/rag_backend/indexing.py
@@ -1,0 +1,118 @@
+"""Index management for workbook documents."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import pickle
+from dataclasses import dataclass
+from typing import List, Optional
+
+from openai import AzureOpenAI
+
+from .chunking import chunk_text
+from .documents import load_document
+from .embeddings import embed_texts
+
+
+@dataclass
+class IndexFile:
+    pkl_path: str
+    chunks: List[str]
+    embeddings: List[List[float]]
+    signature: str
+
+
+def file_signature(path: str) -> str:
+    hasher = hashlib.sha256()
+    with open(path, "rb") as file:
+        for block in iter(lambda: file.read(1024 * 1024), b""):
+            hasher.update(block)
+    stat = os.stat(path)
+    hasher.update(str(stat.st_size).encode())
+    hasher.update(str(int(stat.st_mtime)).encode())
+    return hasher.hexdigest()
+
+
+def pkl_path_for(doc_path: str, embedding_model: str) -> str:
+    base = os.path.basename(doc_path)
+    return os.path.join(
+        os.path.dirname(doc_path), f"{base}.{embedding_model}.idx.pkl"
+    )
+
+
+def load_index_if_valid(doc_path: str, embedding_model: str) -> Optional[IndexFile]:
+    pkl_path = pkl_path_for(doc_path, embedding_model)
+    if not os.path.exists(pkl_path):
+        return None
+    try:
+        with open(pkl_path, "rb") as file:
+            payload = pickle.load(file)
+    except Exception:  # pragma: no cover - defensive
+        return None
+
+    if not isinstance(payload, dict):
+        return None
+    if payload.get("embedding_model") != embedding_model:
+        return None
+    if payload.get("doc_signature") != file_signature(doc_path):
+        return None
+
+    return IndexFile(
+        pkl_path=pkl_path,
+        chunks=payload["chunks"],
+        embeddings=payload["embeddings"],
+        signature=payload["doc_signature"],
+    )
+
+
+def build_index(
+    doc_path: str,
+    client: AzureOpenAI,
+    embedding_model: str,
+) -> IndexFile:
+    raw_text = load_document(doc_path)
+    chunks = chunk_text(raw_text, 1500, 150)
+    if not chunks:
+        raise RuntimeError(f"No text extracted from {doc_path}")
+
+    embeddings = embed_texts(client, embedding_model, chunks)
+    signature = file_signature(doc_path)
+    payload = {
+        "doc_signature": signature,
+        "embedding_model": embedding_model,
+        "chunks": chunks,
+        "embeddings": embeddings,
+    }
+    pkl_path = pkl_path_for(doc_path, embedding_model)
+    with open(pkl_path, "wb") as file:
+        pickle.dump(payload, file)
+    return IndexFile(
+        pkl_path=pkl_path,
+        chunks=chunks,
+        embeddings=embeddings,
+        signature=signature,
+    )
+
+
+def ensure_index(
+    doc_path: str,
+    client: AzureOpenAI,
+    embedding_model: str,
+    rebuild: bool = False,
+) -> IndexFile:
+    if not rebuild:
+        cached = load_index_if_valid(doc_path, embedding_model)
+        if cached:
+            return cached
+    return build_index(doc_path, client, embedding_model)
+
+
+def list_xlsx(source_dir: str) -> List[str]:
+    if not os.path.isdir(source_dir):
+        raise FileNotFoundError(f"Source dir not found: {source_dir}")
+    return sorted(
+        os.path.join(source_dir, name)
+        for name in os.listdir(source_dir)
+        if name.lower().endswith((".xlsx", ".xls"))
+    )

--- a/rag_backend/logging_utils.py
+++ b/rag_backend/logging_utils.py
@@ -1,0 +1,27 @@
+"""Logging helpers for persisting query metadata."""
+
+from __future__ import annotations
+
+import csv
+import os
+from typing import Any, Dict
+
+
+def log_query(log_path: str, row: Dict[str, Any]) -> None:
+    file_exists = os.path.exists(log_path)
+    with open(log_path, "a", newline="", encoding="utf-8") as file:
+        writer = csv.DictWriter(
+            file,
+            fieldnames=[
+                "timestamp",
+                "question",
+                "top_k",
+                "prompt_tokens",
+                "completion_tokens",
+                "total_tokens",
+                "duration_sec",
+            ],
+        )
+        if not file_exists:
+            writer.writeheader()
+        writer.writerow(row)

--- a/rag_backend/retrieval.py
+++ b/rag_backend/retrieval.py
@@ -1,0 +1,79 @@
+"""Retrieval helpers for answering questions with Azure OpenAI."""
+
+from __future__ import annotations
+
+import time
+from typing import Dict, List, Tuple
+
+from openai import AzureOpenAI
+
+from .embeddings import cosine_similarity
+
+
+def retrieve_top_k(
+    client: AzureOpenAI,
+    embedding_model: str,
+    question: str,
+    all_chunks: List[str],
+    all_embeddings: List[List[float]],
+    k: int,
+) -> List[Tuple[int, float]]:
+    question_embedding = (
+        client.embeddings.create(model=embedding_model, input=[question]).data[0].embedding
+    )
+    similarities = [
+        (index, cosine_similarity(question_embedding, embedding))
+        for index, embedding in enumerate(all_embeddings)
+    ]
+    similarities.sort(key=lambda item: item[1], reverse=True)
+    return similarities[:k]
+
+
+def build_messages(retrieved_chunks: List[str], question: str) -> List[Dict[str, str]]:
+    context_block = "\n\n".join(
+        [f"[Chunk {index + 1}]\n{chunk}" for index, chunk in enumerate(retrieved_chunks)]
+    )
+    system_text = (
+        "You are a helpful AI assistant. Use ONLY the provided context to answer the question. "
+        "If the answer is not in the context, say you don't know and suggest what would help."
+    )
+    user_text = (
+        "Here is the context from the document(s):\n"
+        f"{context_block}\n\n"
+        f"Question: {question}\n\n"
+        "Answer clearly. If relevant, quote short snippets."
+    )
+    return [
+        {"role": "system", "content": system_text},
+        {"role": "user", "content": user_text},
+    ]
+
+
+def ask_llm(
+    client: AzureOpenAI,
+    chat_deployment: str,
+    messages: List[Dict[str, str]],
+    *,
+    temperature: float = 1,
+    max_completion_tokens: int = 10000,
+) -> Tuple[str, Dict[str, int | None], float]:
+    start_time = time.time()
+    completion = client.chat.completions.create(
+        model=chat_deployment,
+        messages=messages,
+        max_completion_tokens=max_completion_tokens,
+        temperature=temperature,
+    )
+    duration = time.time() - start_time
+    message = completion.choices[0].message
+    usage = getattr(completion, "usage", None)
+    tokens: Dict[str, int | None] = (
+        {
+            "prompt_tokens": getattr(usage, "prompt_tokens", None),
+            "completion_tokens": getattr(usage, "completion_tokens", None),
+            "total_tokens": getattr(usage, "total_tokens", None),
+        }
+        if usage
+        else {}
+    )
+    return (message.content or "").strip(), tokens, duration

--- a/rag_backend/service.py
+++ b/rag_backend/service.py
@@ -1,0 +1,142 @@
+"""Service layer orchestrating build and ask operations."""
+
+from __future__ import annotations
+
+import os
+import time
+from typing import List
+
+from .api_models import (
+    AskBody,
+    AskErrorResponse,
+    AskSuccessResponse,
+    BuildBody,
+    BuildResponse,
+    IndexedFileSummary,
+    ProjectDashboardStatus,
+    to_token_usage,
+)
+from .azure import AZURE_CLIENT
+from .indexing import ensure_index, list_xlsx
+from .logging_utils import log_query
+from .retrieval import ask_llm, build_messages, retrieve_top_k
+from .settings import AZURE_SETTINGS, DEFAULT_TOP_K, LOG_PATH, SOURCE_DIR
+from project_dashboard import load_project_tasks
+
+
+def _load_dashboard_status() -> ProjectDashboardStatus:
+    try:
+        dashboard = load_project_tasks()
+    except FileNotFoundError:
+        dashboard = {"ok": False, "error": "Project tasks workbook not found."}
+    except Exception as exc:  # pragma: no cover - defensive
+        dashboard = {"ok": False, "error": str(exc)}
+    return ProjectDashboardStatus(**dashboard)
+
+
+def handle_build_request(request: BuildBody) -> BuildResponse:
+    xlsx_list = list_xlsx(SOURCE_DIR)
+    if not xlsx_list:
+        return BuildResponse(
+            built=[],
+            message="No .xlsx/.xls files found in ./data_sources.",
+            project_dashboard=_load_dashboard_status(),
+        )
+
+    built: List[IndexedFileSummary] = []
+    for path in xlsx_list:
+        index_file = ensure_index(
+            path,
+            AZURE_CLIENT,
+            AZURE_SETTINGS.embedding_deployment,
+            rebuild=request.rebuild,
+        )
+        built.append(
+            IndexedFileSummary(
+                xlsx=os.path.basename(path),
+                pkl=os.path.basename(index_file.pkl_path),
+                chunks=len(index_file.chunks),
+                signature=index_file.signature[:16],
+            )
+        )
+
+    return BuildResponse(
+        built=built,
+        project_dashboard=_load_dashboard_status(),
+    )
+
+
+def handle_ask_request(request: AskBody) -> AskSuccessResponse | AskErrorResponse:
+    top_k = request.top_k or DEFAULT_TOP_K
+    temperature = 1 if request.temperature is None else request.temperature
+
+    try:
+        xlsx_list = list_xlsx(SOURCE_DIR)
+    except FileNotFoundError:
+        return AskErrorResponse(
+            error="No .xlsx/.xls files in ./data_sources. Build first via /build."
+        )
+
+    if not xlsx_list:
+        return AskErrorResponse(
+            error="No .xlsx/.xls files in ./data_sources. Build first via /build."
+        )
+
+    all_chunks: List[str] = []
+    all_embeddings: List[List[float]] = []
+    for path in xlsx_list:
+        index_file = ensure_index(
+            path,
+            AZURE_CLIENT,
+            AZURE_SETTINGS.embedding_deployment,
+            rebuild=False,
+        )
+        all_chunks.extend(index_file.chunks)
+        all_embeddings.extend(index_file.embeddings)
+
+    if not all_chunks:
+        return AskErrorResponse(
+            error="No indexed data available. Call /build to generate embeddings first."
+        )
+
+    top = retrieve_top_k(
+        AZURE_CLIENT,
+        AZURE_SETTINGS.embedding_deployment,
+        request.question,
+        all_chunks,
+        all_embeddings,
+        k=top_k,
+    )
+    retrieved_chunks = [all_chunks[index] for index, _ in top]
+    top_scores = [round(score, 4) for _, score in top]
+
+    messages = build_messages(retrieved_chunks, request.question)
+    answer, usage, duration = ask_llm(
+        AZURE_CLIENT,
+        AZURE_SETTINGS.chat_deployment,
+        messages,
+        temperature=temperature,
+        max_completion_tokens=10000,
+    )
+
+    now_iso = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime())
+    log_query(
+        LOG_PATH,
+        {
+            "timestamp": now_iso,
+            "question": request.question,
+            "top_k": top_k,
+            "prompt_tokens": usage.get("prompt_tokens"),
+            "completion_tokens": usage.get("completion_tokens"),
+            "total_tokens": usage.get("total_tokens"),
+            "duration_sec": round(duration, 3),
+        },
+    )
+
+    return AskSuccessResponse(
+        answer=answer,
+        usage=to_token_usage(usage),
+        duration_sec=round(duration, 3),
+        top_scores=top_scores,
+        indexed_files=[os.path.basename(path) for path in xlsx_list],
+    )

--- a/rag_backend/settings.py
+++ b/rag_backend/settings.py
@@ -1,0 +1,75 @@
+"""Application configuration and shared constants."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+try:  # pragma: no cover - defensive import guard
+    import config  # type: ignore
+except Exception:  # pragma: no cover - defensive
+    config = None  # type: ignore
+
+
+@dataclass(frozen=True)
+class AzureSettings:
+    """Configuration required to communicate with Azure OpenAI."""
+
+    endpoint_url: str
+    chat_deployment: str
+    embedding_deployment: str
+    api_key: str
+    api_version: str = "2025-01-01-preview"
+
+
+ENVIRONMENT_VARIABLES = {
+    "ENDPOINT_URL": "endpoint_url",
+    "DEPLOYMENT_NAME": "chat_deployment",
+    "EMBEDDING_DEPLOYMENT_NAME": "embedding_deployment",
+    "AZURE_OPENAI_API_KEY": "api_key",
+}
+
+
+def _lookup_setting(name: str) -> Optional[str]:
+    """Fetch a configuration value from the environment or config module."""
+
+    env_value = os.getenv(name)
+    if env_value:
+        return env_value
+
+    if config is not None and hasattr(config, name):
+        value = getattr(config, name)
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+
+def load_azure_settings() -> AzureSettings:
+    """Load Azure OpenAI credentials, raising an informative error when missing."""
+
+    values: dict[str, Optional[str]] = {
+        alias: _lookup_setting(env_name)
+        for env_name, alias in ENVIRONMENT_VARIABLES.items()
+    }
+    missing = [name for name, value in values.items() if not value]
+    if missing:
+        missing_display = ", ".join(sorted(missing))
+        raise RuntimeError(
+            "Please set ENDPOINT_URL, DEPLOYMENT_NAME, AZURE_OPENAI_API_KEY, "
+            "EMBEDDING_DEPLOYMENT_NAME (env or config.py). Missing: "
+            f"{missing_display}."
+        )
+
+    return AzureSettings(**values)  # type: ignore[arg-type]
+
+
+AZURE_SETTINGS = load_azure_settings()
+
+SOURCE_DIR = "./data_sources"
+DEFAULT_TOP_K = 3
+LOG_DIR = "./logs"
+LOG_PATH = os.path.join(LOG_DIR, "query_logs.csv")
+
+os.makedirs(SOURCE_DIR, exist_ok=True)
+os.makedirs(LOG_DIR, exist_ok=True)


### PR DESCRIPTION
## Summary
- extract configuration, document ingestion, indexing, retrieval, and logging helpers into a dedicated `rag_backend` package
- keep `app.py` focused on FastAPI wiring by delegating to shared API models and service functions
- centralize Azure client creation and project dashboard status handling inside the service layer

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68e49b20279c832dbdfd23a299115434